### PR TITLE
Fix Undefined variable warning in single post template

### DIFF
--- a/single.php
+++ b/single.php
@@ -33,7 +33,7 @@ get_header();
 				<?php the_title( '<h1 class="entry-title article">', '</h1>' ); ?>
 				</div>
 
-				<?php echo get_the_post_thumbnail($post_id, 'full', array( 'class' => 'img-fluid' )); ?>
+				<?php echo get_the_post_thumbnail(get_the_ID(), 'full', array( 'class' => 'img-fluid' )); ?>
 
 			</header>
 


### PR DESCRIPTION
Replace non-existent $post_id variable with get_the_ID()

![CleanShot 2024-07-01 at 09 58 04@2x](https://github.com/asuengineering/pitchfork/assets/173391/86057ecd-f38a-4a47-9c35-13d9c843aa86)
