### PR TITLE
Use get_parent_theme_file_uri() to load editor stylesheet

### DIFF
--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -85,7 +85,7 @@ if ( ! function_exists( 'pitchfork_gutenberg_css' ) ) {
 	 */
 	function pitchfork_gutenberg_css() {
 		add_theme_support( 'editor-styles' );
-		add_editor_style( 'dist/css/theme.css' );
+		add_editor_style( get_parent_theme_file_uri( 'dist/css/theme.css' ) );
 	}
 }
 add_action( 'after_setup_theme', 'pitchfork_gutenberg_css' );


### PR DESCRIPTION
This will ensure that if a child theme is in use, the parent pitchfork theme styles will be loaded in the editor.

By default, add_editor_style is relative to the active theme root, so if a child theme is in use, the pitchfork styles will not be loaded.